### PR TITLE
Show names of all speakers

### DIFF
--- a/FOSSAsia/Event.swift
+++ b/FOSSAsia/Event.swift
@@ -51,7 +51,7 @@ struct Event {
     let trackCode: Track
     let title: String
     let shortDescription: String
-    let speaker: Speaker?
+    let speakers: [Speaker]?
     let location: String
     let startDateTime: NSDate
     let endDateTime: NSDate

--- a/FOSSAsia/EventInfoView.swift
+++ b/FOSSAsia/EventInfoView.swift
@@ -20,7 +20,7 @@ class EventInfoView: UIView {
         
         if let delegate = self.delegate {
             eventLabel.text = delegate.eventName
-            speakerLabel.text = delegate.speakerName
+            speakerLabel.text = delegate.speakerNames
             locationLabel.text = delegate.timing
         }
     }

--- a/FOSSAsia/EventViewModel.swift
+++ b/FOSSAsia/EventViewModel.swift
@@ -17,7 +17,7 @@ protocol EventTypePresentable {
 
 protocol EventDetailsPresentable {
     var eventName: String {get}
-    var speakerName: String {get}
+    var speakerNames: String {get}
     var timing: String {get}
     var isFavorite: Bool {get}
 }
@@ -41,7 +41,7 @@ struct EventViewModel: EventTypePresentable, EventDetailsPresentable, EventDescr
     let track: Observable<UIColor>
     let title: Observable<String>
     let shortDescription: Observable<String>
-    let speaker: Observable<Speaker?>
+    let speakers: Observable<[Speaker]?>
     let location: Observable<String>
     let startDateTime: Observable<NSDate>
     let endDateTime: Observable<NSDate>
@@ -55,7 +55,7 @@ struct EventViewModel: EventTypePresentable, EventDetailsPresentable, EventDescr
         track = Observable(event.trackCode.getTrackColor())
         title = Observable(event.title)
         shortDescription = Observable(event.shortDescription)
-        speaker = Observable(event.speaker)
+        speakers = Observable(event.speakers)
         location = Observable(event.location)
         startDateTime = Observable(event.startDateTime)
         endDateTime = Observable(event.endDateTime)
@@ -96,7 +96,14 @@ extension EventViewModel {
 // MARK: - EventPresentable Conformance
 extension EventViewModel {
     var eventName: String { return self.title.value }
-    var speakerName: String { return (self.speaker.value?.name)! }
+    var speakerNames: String {
+        let speakers = self.speakers.value
+        var speakersNames: [String] = []
+        for speaker in speakers! {
+            speakersNames.append(speaker.name)
+        }
+        return speakersNames.joinWithSeparator(", ")
+    }
     var timing: String {
         let startTime = self.startDateTime.value.formattedDateWithFormat("HH:mm")
         let endTime = self.endDateTime.value.formattedDateWithFormat("HH:mm")

--- a/FOSSAsia/FossAsiaEventsService.swift
+++ b/FOSSAsia/FossAsiaEventsService.swift
@@ -137,19 +137,24 @@ struct FossAsiaEventsService: EventsServiceProtocol {
                             sessionId = session["id"].int,
                             sessionTitle = session["title"].string,
                             sessionDescription = session["description"].string,
-                            sessionSpeakerName = session["speakers"][0]["name"].string,
+                            sessionSpeakers = session["speakers"].array,
                             sessionStartDateTime = session["begin"].string,
                             sessionEndDateTime = session["end"].string else {
                                 continue
                         }
                         
+                        var sessionSpeakersNames: [Speaker] = []
+                        for speaker in sessionSpeakers {
+                            let name = speaker["name"].string!
+                            sessionSpeakersNames.append(Speaker(name: name))
+                        }
                         
                         // FIX ME: - Location is hardcoded for now
                         let tempSession = Event(id: sessionId,
                             trackCode: Event.Track(rawValue: trackId)!,
                             title: sessionTitle,
                             shortDescription: sessionDescription,
-                            speaker: Speaker(name: sessionSpeakerName),
+                            speakers: sessionSpeakersNames,
                             location: "Biopolis Matrix",
                             startDateTime: NSDate(string: sessionStartDateTime, formatString: self.dateFormatString),
                             endDateTime: NSDate(string: sessionEndDateTime, formatString: self.dateFormatString),


### PR DESCRIPTION
Currently the session view shows name of only one speaker. This is the one that appears first in the JSON. With this PR, names of all the speakers are displayed. Screenshot attached.

![simulator screen shot 21-feb-2016 7 41 19 pm](https://cloud.githubusercontent.com/assets/6842317/13203067/48b4744a-d8d4-11e5-8d02-952ca3968af8.png)
