### PR TITLE
Updated 2016 link to 2018 on More tab. Fixed #40

### DIFF
--- a/FOSSAsia/More.storyboard
+++ b/FOSSAsia/More.storyboard
@@ -73,7 +73,7 @@
                                                         <constraint firstAttribute="height" constant="29" id="oiw-Jm-bJg"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="2016.fossasia.org" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKY-UR-BVQ">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="2018.fossasia.org" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKY-UR-BVQ">
                                                     <frame key="frameInset" minX="45" minY="11" width="547" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
On More tab it was showing link 2016.fossasia.org and opening the the same link. Now it is updated to 2018.fossasia.org. Fixed #40 

**Before:**
<img src="https://user-images.githubusercontent.com/20956124/32130692-c10812b0-bbba-11e7-8b44-413069dd357a.png">

**After:**
![simulator screen shot - iphone x - 2017-11-04 at 16 45 03](https://user-images.githubusercontent.com/20956124/32404868-87ef0310-c17f-11e7-80ae-f96d48cd7eed.png)

